### PR TITLE
Integrates HTML-to-PDF rendering with Freemarker templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,16 @@
             <artifactId>openpdf</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-core</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-pdfbox</artifactId>
+            <version>1.0.10</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/resources/templates/retirementanalysis.ftl
+++ b/src/main/resources/templates/retirementanalysis.ftl
@@ -1,37 +1,19 @@
 <!DOCTYPE html>
-<html lang="de">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
 <head>
-    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Altersvorsorge One-Pager</title>
-    <style>
-        * {
-            box-sizing: border-box;
-            margin: 0;
-            padding: 0;
-        }
-
+    <style type="text/css">
         body {
-            font-family: Arial, sans-serif;
+            font-family: Helvetica, sans-serif;
             margin: 20px;
         }
 
         header {
             width: 100%;
-            display: flex;
-            justify-content: flex-start;
-            align-items: center;
-            margin-bottom: 20px;
             border-bottom: 2px solid #ccc;
             padding-bottom: 8px;
-        }
-
-        .content {
-            max-width: 90%;
-            margin: 40px auto; /* zentriert */
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
+            margin-bottom: 20px;
         }
 
         h1 {
@@ -39,30 +21,27 @@
             text-align: center;
         }
 
-        .text-container {
-            max-width: 800px;
-            margin-bottom: 20px;
-            text-align: left;
-            line-height: 1.5;
+        .content {
+            max-width: 90%;
+            margin: 40px auto;
         }
 
         table {
             border-collapse: collapse;
-            width: 60%; /* zentrierte, schmalere Tabelle */
+            width: 60%;
             margin: 40px auto;
             text-align: center;
         }
 
-        th,
-        td {
+        th, td {
             border: 1px solid #ccc;
-            padding: 8px;
+            padding: 6px;
             text-align: center;
         }
 
         th {
             background-color: #007bff;
-            color: white;
+            color: #ffffff;
         }
 
         tr:nth-child(even) {
@@ -72,9 +51,7 @@
         .canvas-container {
             width: 60%;
             margin: 20px auto;
-            display: flex;
-            justify-content: center;
-            align-items: center;
+            text-align: center;
         }
 
         img.chart {
@@ -82,13 +59,77 @@
             height: auto;
             display: block;
         }
-    </style>
 
+        @page {
+            size: A4 portrait;
+            margin: -20mm 8mm 8mm 8mm;
+        }
+
+        @media print {
+            body {
+                font-size: 16px;
+                margin: 0;
+                transform: scale(0.85);
+                transform-origin: top left;
+            }
+
+            header {
+                margin-bottom: 16px;
+                margin-top: 0;
+                padding-bottom: 4px;
+                padding-top: 0;
+            }
+
+            h1 {
+                font-size: 14pt;
+                margin-bottom: 12px;
+                margin-top: 0;
+            }
+
+            p {
+                white-space: normal;
+                word-spacing: normal;
+            }
+
+
+            .content {
+                margin-top: 0;
+            }
+
+            .table-container,
+            .canvas-container,
+            .text-container {
+                width: 100%;
+                max-width: none;
+            }
+
+            table { width: 100%; }
+
+            .table-container {
+                margin: 0 auto;
+                padding-bottom: 1px;
+            }
+
+            .canvas-container {
+                margin: 0 auto;
+                padding-top: 1px;
+                text-align: center;
+                overflow: hidden;
+            }
+
+            img.chart {
+                width: 100%;
+                height: auto;
+                display: block;
+                margin: 0 auto;
+            }
+        }
+    </style>
 </head>
 <body>
 
 <header>
-    <img src="/logo.png" alt="Logo" height="50">
+    <img src="logo.png" alt="Logo" height="50"/>
 </header>
 
 <h1>Auswertung Altersvorsorge</h1>
@@ -109,83 +150,85 @@
         </p>
     </div>
 
-    <table>
-        <thead>
-        <tr>
-            <th>Vorsorgequelle</th>
-            <th>Bereits erreicht ${analysis.analysisYear}<br>(€ / Monat)</th>
-            <th>Projektion ${analysis.projectionYear}<br>(€ / Monat)</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td>Gesetzliche Rente</td>
-            <td>${analysis.statutoryPension?string["#,##0.00"]}</td>
-            <td>${analysis.statutoryPensionProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td>Sonstige Einnahmen</td>
-            <td>${analysis.otherIncome?string["#,##0.00"]}</td>
-            <td>${analysis.otherIncomeProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td>Betriebliche &amp; geförderte Vorsorge</td>
-            <td>${analysis.occupationalPension?string["#,##0.00"]}</td>
-            <td>${analysis.occupationalPensionProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td>Private Vorsorge</td>
-            <td>${analysis.privatePension?string["#,##0.00"]}</td>
-            <td>${analysis.privatePensionProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td><b>Gesamtsumme Vorsorge</b></td>
-            <td>${(analysis.statutoryPension + analysis.otherIncome + analysis.occupationalPension + analysis.privatePension)?string["#,##0.00"]}</td>
-            <td>${(analysis.statutoryPensionProjection + analysis.otherIncomeProjection + analysis.occupationalPensionProjection + analysis.privatePensionProjection)?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td><b>Netto-Einkommen</b></td>
-            <td>${analysis.netMonthlyIncome?string["#,##0.00"]}</td>
-            <td>${analysis.netMonthlyIncomeProjection?string["#,##0.00"]}</td>
-
-        </tr>
-        <tr>
-            <td><b>Richtwert (80% Netto)</b></td>
-            <td>${analysis.targetValue?string["#,##0.00"]}</td>
-            <td>${analysis.targetValueProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td><b>Mindestsoll</b></td>
-            <td>${analysis.minTargetCurrent?string["#,##0.00"]}</td>
-            <td>${analysis.minTargetProjection?string["#,##0.00"]}</td>
-        </tr>
-        <tr>
-            <td><b>Versorgungslücke</b></td>
-            <td>${analysis.gapCurrent?string["#,##0.00"]}</td>
-            <td>${analysis.gapProjection?string["#,##0.00"]}</td>
-        </tr>
-        </tbody>
-    </table>
-
-    <div class="canvas-container">
-        <div style="margin:20px 0;">
-            <img class="chart" src="/chart.png" alt="Diagramm Altersvorsorge" style="max-width:800px;">
-        </div>
+    <div class="table-container">
+        <table>
+            <thead>
+            <tr>
+                <th>Vorsorgequelle</th>
+                <th>
+                    Bereits erreicht ${analysis.analysisYear}<br/> (&#8364;/Monat)
+                </th>
+                <th>
+                    Projektion ${analysis.projectionYear}<br/> (&#8364;/Monat)
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>Gesetzliche Rente</td>
+                <td>${analysis.statutoryPension?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.statutoryPensionProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td>Sonstige Einnahmen</td>
+                <td>${analysis.otherIncome?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.otherIncomeProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td>Betriebliche &amp; geförderte Vorsorge</td>
+                <td>${analysis.occupationalPension?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.occupationalPensionProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td>Private Vorsorge</td>
+                <td>${analysis.privatePension?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.privatePensionProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td><b>Gesamtsumme Vorsorge</b></td>
+                <td>${(analysis.statutoryPension + analysis.otherIncome + analysis.occupationalPension + analysis.privatePension)?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${(analysis.statutoryPensionProjection + analysis.otherIncomeProjection + analysis.occupationalPensionProjection + analysis.privatePensionProjection)?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td><b>Netto-Einkommen</b></td>
+                <td>${analysis.netMonthlyIncome?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.netMonthlyIncomeProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td><b>Richtwert (80% Netto)</b></td>
+                <td>${analysis.targetValue?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.targetValueProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td><b>Mindestsoll</b></td>
+                <td>${analysis.minTargetCurrent?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.minTargetProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            <tr>
+                <td><b>Versorgungslücke</b></td>
+                <td>${analysis.gapCurrent?string["#,##0.00"]}&#160;&#8364;</td>
+                <td>${analysis.gapProjection?string["#,##0.00"]}&#160;&#8364;</td>
+            </tr>
+            </tbody>
+        </table>
     </div>
 
+    <div class="canvas-container">
+        <img class="chart" src="chart.png" alt="Diagramm Altersvorsorge"/>
+    </div>
 
     <div class="text-container">
         <p>
             Aus der Gegenüberstellung ergibt sich eine Versorgungslücke:
             Trotz solider Basis durch die gesetzliche Rente und sonstige Einnahmen reichen die betrieblichen
-            und privaten Vorsorgeleistungen aktuell nicht aus, um den Richtwert vollständig zu erreichen.
-            Die Lücke beträgt im Jahr ${analysis.analysisYear} rund ${analysis.gapCurrent?string["#,##0"]} €,
-            im Jahr ${analysis.projectionYear} – inflationsbedingt – etwa ${analysis.gapProjection?string["#,##0"]} €.
+            und privaten Vorsorgeleistungen aktuell nicht aus, um den&#160;Richtwert vollständig zu erreichen.
+            Die Lücke beträgt im Jahr ${analysis.analysisYear} rund ${analysis.gapCurrent?string["#,##0"]}&#8239;&#8364;,
+            im Jahr ${analysis.projectionYear} – inflationsbedingt – etwa ${analysis.gapProjection?string["#,##0"]}&#8239;&#8364;.
             Eine gezielte Stärkung der betrieblichen und privaten Vorsorge ist daher empfehlenswert.
         </p>
+
     </div>
 </div>
-
 
 </body>
 </html>


### PR DESCRIPTION
Replaces the previous PDF generation approach with an HTML-to-PDF rendering workflow using Freemarker and OpenHTML to PDF. Adds dependencies for OpenHTML to PDF core and PDFBox.

Updates the controller to generate dynamic HTML content from a Freemarker template and render it as a PDF for browser display. Removes the temporary file-based PDF creation method.

Improves the retirement analysis template for better compatibility with PDF rendering, including enhanced structure, table formatting, and print-specific styling.

Facilitates dynamic and scalable PDF generation for retirement analysis reports.