### PR TITLE
Removes unnecessary comment in category geometry calculation

### DIFF
--- a/src/main/java/com/dj/retirementanalysis/helper/CustomStackedBarRenderer.java
+++ b/src/main/java/com/dj/retirementanalysis/helper/CustomStackedBarRenderer.java
@@ -53,8 +53,7 @@ public class CustomStackedBarRenderer extends StackedBarRenderer {
 
         if (pass == 1 && row == dataset.getRowCount() - 1) {
             Comparable<?> colKey = dataset.getColumnKey(column);
-
-            // Kategorie-Geometrie ermitteln
+            
             double catStart = domainAxis.getCategoryStart(column, dataset.getColumnCount(), dataArea, plot.getDomainAxisEdge());
             double catEnd   = domainAxis.getCategoryEnd(column, dataset.getColumnCount(), dataArea, plot.getDomainAxisEdge());
             double catWidth = catEnd - catStart;


### PR DESCRIPTION
Cleans up redundant comment in the calculation logic for category geometry in the custom stacked bar renderer. This improves code readability without affecting functionality.